### PR TITLE
fix: improve handling of whitespace and empty spans

### DIFF
--- a/src/serializers.js
+++ b/src/serializers.js
@@ -19,8 +19,21 @@ function block(props) {
   return renderChildren(props)
 }
 
-function RawMarkSerializer(char, props) {
-  return `${char}${renderChildren(props)}${char}`
+function RawMarkSerializer(char, padWhitespace, props) {
+  const children = renderChildren(props)
+
+  if (padWhitespace) {
+    const startContent = children.search(/\S/)
+    const endContent = children.search(/\S(?=\s*$)/)
+
+    const start = startContent == -1 ? '' : children.substring(0, startContent)
+    const end = endContent == -1 ? '' : children.substring(endContent + 1)
+    const content = children.substring(startContent, endContent + 1)
+
+    return `${start}${char}${content}${char}${end}`
+  }
+
+  return `${char}${children}${char}`
 }
 
 function link(props) {
@@ -58,21 +71,21 @@ function hardBreak() {
 module.exports = {
   types: {
     block,
-    image
+    image,
   },
 
   marks: {
-    'strike-through': RawMarkSerializer.bind(null, '~~'),
-    em: RawMarkSerializer.bind(null, '_'),
-    code: RawMarkSerializer.bind(null, '`'),
-    strong: RawMarkSerializer.bind(null, '**'),
+    'strike-through': RawMarkSerializer.bind(null, '~~', true),
+    em: RawMarkSerializer.bind(null, '_', true),
+    code: RawMarkSerializer.bind(null, '`', false),
+    strong: RawMarkSerializer.bind(null, '**', true),
     underline: renderChildren,
-    link
+    link,
   },
 
   list,
   listItem,
   container,
   hardBreak,
-  markFallback: renderChildren
+  markFallback: renderChildren,
 }

--- a/src/serializers.js
+++ b/src/serializers.js
@@ -26,8 +26,13 @@ function RawMarkSerializer(char, padWhitespace, props) {
     const startContent = children.search(/\S/)
     const endContent = children.search(/\S(?=\s*$)/)
 
-    const start = startContent == -1 ? '' : children.substring(0, startContent)
-    const end = endContent == -1 ? '' : children.substring(endContent + 1)
+    if (endContent == -1 || startContent == -1) {
+      return children
+    }
+
+    const start = children.substring(0, startContent)
+    const end = children.substring(endContent + 1)
+
     const content = children.substring(startContent, endContent + 1)
 
     return `${start}${char}${content}${char}${end}`

--- a/src/serializers.js
+++ b/src/serializers.js
@@ -76,7 +76,7 @@ function hardBreak() {
 module.exports = {
   types: {
     block,
-    image,
+    image
   },
 
   marks: {
@@ -85,12 +85,12 @@ module.exports = {
     code: RawMarkSerializer.bind(null, '`', false),
     strong: RawMarkSerializer.bind(null, '**', true),
     underline: renderChildren,
-    link,
+    link
   },
 
   list,
   listItem,
   container,
   hardBreak,
-  markFallback: renderChildren,
+  markFallback: renderChildren
 }

--- a/src/toMarkdown.js
+++ b/src/toMarkdown.js
@@ -7,6 +7,40 @@ const {
 
 const mdSerializers = require('./serializers')
 
+const disallowedEmptyMarks = ['strike-through', 'em', 'strong', 'underline']
+
+const sanitizeEmptyMarkedSpans = (blocks = []) => {
+  const sanitizedBlock = (block) => {
+    if (block._type === 'block' && Array.isArray(block.children)) {
+      const newBlock = Object.assign({}, block)
+
+      newBlock.children = sanitizeEmptyMarkedSpans(block.children)
+
+      return newBlock
+    }
+
+    if (block._type === 'span' && block.text.length == 0 && Array.isArray(block.marks)) {
+      const allowedEmptyMarks = block.marks.filter((mark) => {
+        return !disallowedEmptyMarks.includes(mark)
+      })
+
+      if (allowedEmptyMarks.length == 0) {
+        return null
+      } else {
+        return Object.assign({}, block, {
+          marks: allowedEmptyMarks,
+        })
+      }
+    }
+
+    return block
+  }
+
+  return Array.isArray(blocks)
+    ? blocks.map(sanitizedBlock).filter((block) => !!block)
+    : sanitizedBlock(blocks)
+}
+
 const renderNode = (render, props, childNodes) => {
   const children = childNodes || (props.node && props.node.children)
   return render(Object.assign({}, props, {children}))
@@ -16,7 +50,7 @@ const {defaultSerializers, serializeSpan} = getSerializers(renderNode)
 const markdownSerializers = mergeSerializers(defaultSerializers, mdSerializers)
 
 const toMarkdown = (block, options = {}) => {
-  const blocks = block || []
+  const blocks = sanitizeEmptyMarkedSpans(block || [])
   const serializers = mergeSerializers(markdownSerializers, options.serializers || {})
   const props = Object.assign({}, options, {blocks, serializers, listNestMode: 'last-child'})
   return blocksToNodes(renderNode, props, defaultSerializers, serializeSpan).trim()

--- a/src/toMarkdown.js
+++ b/src/toMarkdown.js
@@ -2,7 +2,7 @@ const {
   getImageUrl,
   getSerializers,
   blocksToNodes,
-  mergeSerializers
+  mergeSerializers,
 } = require('@sanity/block-content-to-hyperscript/internals')
 
 const mdSerializers = require('./serializers')

--- a/src/toMarkdown.js
+++ b/src/toMarkdown.js
@@ -2,7 +2,7 @@ const {
   getImageUrl,
   getSerializers,
   blocksToNodes,
-  mergeSerializers,
+  mergeSerializers
 } = require('@sanity/block-content-to-hyperscript/internals')
 
 const mdSerializers = require('./serializers')
@@ -10,7 +10,7 @@ const mdSerializers = require('./serializers')
 const disallowedEmptyMarks = ['strike-through', 'em', 'strong', 'underline']
 
 const sanitizeEmptyMarkedSpans = (blocks = []) => {
-  const sanitizedBlock = (block) => {
+  const sanitizedBlock = block => {
     if (block._type === 'block' && Array.isArray(block.children)) {
       const newBlock = Object.assign({}, block)
 
@@ -20,7 +20,7 @@ const sanitizeEmptyMarkedSpans = (blocks = []) => {
     }
 
     if (block._type === 'span' && block.text.length == 0 && Array.isArray(block.marks)) {
-      const allowedEmptyMarks = block.marks.filter((mark) => {
+      const allowedEmptyMarks = block.marks.filter(mark => {
         return !disallowedEmptyMarks.includes(mark)
       })
 
@@ -28,7 +28,7 @@ const sanitizeEmptyMarkedSpans = (blocks = []) => {
         return null
       } else {
         return Object.assign({}, block, {
-          marks: allowedEmptyMarks,
+          marks: allowedEmptyMarks
         })
       }
     }
@@ -37,7 +37,7 @@ const sanitizeEmptyMarkedSpans = (blocks = []) => {
   }
 
   return Array.isArray(blocks)
-    ? blocks.map(sanitizedBlock).filter((block) => !!block)
+    ? blocks.map(sanitizedBlock).filter(block => !!block)
     : sanitizedBlock(blocks)
 }
 

--- a/test/__snapshots__/toMarkdown.test.js.snap
+++ b/test/__snapshots__/toMarkdown.test.js.snap
@@ -340,12 +340,18 @@ Lorem ipsum"
 
 exports[`061-missing-mark-serializer 1`] = `"A word of _warning;_ Sanity is addictive."`;
 
-exports[`places code symbols appropriately with respect to whitespace 1`] = `"\`   Sanity   \`"`;
+exports[`does not include em symbols around empty content 1`] = `"before after"`;
 
-exports[`places em symbols appropriately with respect to whitespace 1`] = `"_Sanity_"`;
+exports[`does not include strike-through symbols around empty content 1`] = `"before after"`;
+
+exports[`does not include strong symbols around empty content 1`] = `"before after"`;
+
+exports[`places code symbols appropriately with respect to whitespace 1`] = `"before\`   Sanity   \`after"`;
+
+exports[`places em symbols appropriately with respect to whitespace 1`] = `"before   _Sanity_   after"`;
 
 exports[`places nested marks appropriately with respect to whitespace 1`] = `"~~before   **_Sanity_**~~   after"`;
 
-exports[`places strike-through symbols appropriately with respect to whitespace 1`] = `"~~Sanity~~"`;
+exports[`places strike-through symbols appropriately with respect to whitespace 1`] = `"before   ~~Sanity~~   after"`;
 
-exports[`places strong symbols appropriately with respect to whitespace 1`] = `"**Sanity**"`;
+exports[`places strong symbols appropriately with respect to whitespace 1`] = `"before   **Sanity**   after"`;

--- a/test/__snapshots__/toMarkdown.test.js.snap
+++ b/test/__snapshots__/toMarkdown.test.js.snap
@@ -340,6 +340,46 @@ Lorem ipsum"
 
 exports[`061-missing-mark-serializer 1`] = `"A word of _warning;_ Sanity is addictive."`;
 
+exports[`after sanitiziation - allows empty code marks between em marks 1`] = `"_before_\`\`_after_"`;
+
+exports[`after sanitiziation - allows empty code marks between em marks 2`] = `"_before\`\`after_"`;
+
+exports[`after sanitiziation - allows empty code marks between em marks 3`] = `"_before_**\`\`**_after_"`;
+
+exports[`after sanitiziation - allows empty code marks between em marks 4`] = `"_before_\`\`_after_"`;
+
+exports[`after sanitiziation - allows empty code marks between strike-through marks 1`] = `"~~before\`\`after~~"`;
+
+exports[`after sanitiziation - allows empty code marks between strike-through marks 2`] = `"~~before~~_\`\`_~~after~~"`;
+
+exports[`after sanitiziation - allows empty code marks between strike-through marks 3`] = `"~~before~~**\`\`**~~after~~"`;
+
+exports[`after sanitiziation - allows empty code marks between strike-through marks 4`] = `"~~before~~\`\`~~after~~"`;
+
+exports[`after sanitiziation - allows empty code marks between strong marks 1`] = `"**before**\`\`**after**"`;
+
+exports[`after sanitiziation - allows empty code marks between strong marks 2`] = `"**before**_\`\`_**after**"`;
+
+exports[`after sanitiziation - allows empty code marks between strong marks 3`] = `"**before\`\`after**"`;
+
+exports[`after sanitiziation - allows empty code marks between strong marks 4`] = `"**before**\`\`**after**"`;
+
+exports[`after sanitiziation - allows empty code marks between underline marks 1`] = `"before\`\`after"`;
+
+exports[`after sanitiziation - allows empty code marks between underline marks 2`] = `"before_\`\`_after"`;
+
+exports[`after sanitiziation - allows empty code marks between underline marks 3`] = `"before**\`\`**after"`;
+
+exports[`after sanitiziation - allows empty code marks between underline marks 4`] = `"before\`\`after"`;
+
+exports[`allows empty code marks between em marks 1`] = `"_before_\`\`_after_"`;
+
+exports[`allows empty code marks between strike-through marks 1`] = `"~~before~~\`\`~~after~~"`;
+
+exports[`allows empty code marks between strong marks 1`] = `"**before**\`\`**after**"`;
+
+exports[`allows empty code marks between underline marks 1`] = `"before\`\`after"`;
+
 exports[`does not include em symbols around empty content 1`] = `"before after"`;
 
 exports[`does not include strike-through symbols around empty content 1`] = `"before after"`;
@@ -355,3 +395,35 @@ exports[`places nested marks appropriately with respect to whitespace 1`] = `"~~
 exports[`places strike-through symbols appropriately with respect to whitespace 1`] = `"before   ~~Sanity~~   after"`;
 
 exports[`places strong symbols appropriately with respect to whitespace 1`] = `"before   **Sanity**   after"`;
+
+exports[`sanitizes empty em blocks to prevent malformed code syntax 1`] = `"\`before\`\`after\`"`;
+
+exports[`sanitizes empty em blocks to prevent malformed em syntax 1`] = `"_beforeafter_"`;
+
+exports[`sanitizes empty em blocks to prevent malformed strike-through syntax 1`] = `"~~before~~~~after~~"`;
+
+exports[`sanitizes empty em blocks to prevent malformed strong syntax 1`] = `"**before****after**"`;
+
+exports[`sanitizes empty strike-through blocks to prevent malformed code syntax 1`] = `"\`before\`\`after\`"`;
+
+exports[`sanitizes empty strike-through blocks to prevent malformed em syntax 1`] = `"_before__after_"`;
+
+exports[`sanitizes empty strike-through blocks to prevent malformed strike-through syntax 1`] = `"~~beforeafter~~"`;
+
+exports[`sanitizes empty strike-through blocks to prevent malformed strong syntax 1`] = `"**before****after**"`;
+
+exports[`sanitizes empty strong blocks to prevent malformed code syntax 1`] = `"\`before\`\`after\`"`;
+
+exports[`sanitizes empty strong blocks to prevent malformed em syntax 1`] = `"_before__after_"`;
+
+exports[`sanitizes empty strong blocks to prevent malformed strike-through syntax 1`] = `"~~before~~~~after~~"`;
+
+exports[`sanitizes empty strong blocks to prevent malformed strong syntax 1`] = `"**beforeafter**"`;
+
+exports[`sanitizes empty underline blocks to prevent malformed code syntax 1`] = `"\`before\`\`after\`"`;
+
+exports[`sanitizes empty underline blocks to prevent malformed em syntax 1`] = `"_before__after_"`;
+
+exports[`sanitizes empty underline blocks to prevent malformed strike-through syntax 1`] = `"~~before~~~~after~~"`;
+
+exports[`sanitizes empty underline blocks to prevent malformed strong syntax 1`] = `"**before****after**"`;

--- a/test/__snapshots__/toMarkdown.test.js.snap
+++ b/test/__snapshots__/toMarkdown.test.js.snap
@@ -342,33 +342,33 @@ exports[`061-missing-mark-serializer 1`] = `"A word of _warning;_ Sanity is addi
 
 exports[`after sanitiziation - allows empty code marks between em marks 1`] = `"_before_\`\`_after_"`;
 
-exports[`after sanitiziation - allows empty code marks between em marks 2`] = `"_before\`\`after_"`;
+exports[`after sanitiziation - allows empty code marks between em marks 2`] = `"_before_\`\`_after_"`;
 
-exports[`after sanitiziation - allows empty code marks between em marks 3`] = `"_before_**\`\`**_after_"`;
+exports[`after sanitiziation - allows empty code marks between em marks 3`] = `"_before_\`\`_after_"`;
 
 exports[`after sanitiziation - allows empty code marks between em marks 4`] = `"_before_\`\`_after_"`;
 
-exports[`after sanitiziation - allows empty code marks between strike-through marks 1`] = `"~~before\`\`after~~"`;
+exports[`after sanitiziation - allows empty code marks between strike-through marks 1`] = `"~~before~~\`\`~~after~~"`;
 
-exports[`after sanitiziation - allows empty code marks between strike-through marks 2`] = `"~~before~~_\`\`_~~after~~"`;
+exports[`after sanitiziation - allows empty code marks between strike-through marks 2`] = `"~~before~~\`\`~~after~~"`;
 
-exports[`after sanitiziation - allows empty code marks between strike-through marks 3`] = `"~~before~~**\`\`**~~after~~"`;
+exports[`after sanitiziation - allows empty code marks between strike-through marks 3`] = `"~~before~~\`\`~~after~~"`;
 
 exports[`after sanitiziation - allows empty code marks between strike-through marks 4`] = `"~~before~~\`\`~~after~~"`;
 
 exports[`after sanitiziation - allows empty code marks between strong marks 1`] = `"**before**\`\`**after**"`;
 
-exports[`after sanitiziation - allows empty code marks between strong marks 2`] = `"**before**_\`\`_**after**"`;
+exports[`after sanitiziation - allows empty code marks between strong marks 2`] = `"**before**\`\`**after**"`;
 
-exports[`after sanitiziation - allows empty code marks between strong marks 3`] = `"**before\`\`after**"`;
+exports[`after sanitiziation - allows empty code marks between strong marks 3`] = `"**before**\`\`**after**"`;
 
 exports[`after sanitiziation - allows empty code marks between strong marks 4`] = `"**before**\`\`**after**"`;
 
 exports[`after sanitiziation - allows empty code marks between underline marks 1`] = `"before\`\`after"`;
 
-exports[`after sanitiziation - allows empty code marks between underline marks 2`] = `"before_\`\`_after"`;
+exports[`after sanitiziation - allows empty code marks between underline marks 2`] = `"before\`\`after"`;
 
-exports[`after sanitiziation - allows empty code marks between underline marks 3`] = `"before**\`\`**after"`;
+exports[`after sanitiziation - allows empty code marks between underline marks 3`] = `"before\`\`after"`;
 
 exports[`after sanitiziation - allows empty code marks between underline marks 4`] = `"before\`\`after"`;
 
@@ -396,34 +396,34 @@ exports[`places strike-through symbols appropriately with respect to whitespace 
 
 exports[`places strong symbols appropriately with respect to whitespace 1`] = `"before   **Sanity**   after"`;
 
-exports[`sanitizes empty em blocks to prevent malformed code syntax 1`] = `"\`before\`\`after\`"`;
+exports[`sanitizes empty em blocks to prevent malformed code syntax 1`] = `"\`beforeafter\`"`;
 
 exports[`sanitizes empty em blocks to prevent malformed em syntax 1`] = `"_beforeafter_"`;
 
-exports[`sanitizes empty em blocks to prevent malformed strike-through syntax 1`] = `"~~before~~~~after~~"`;
+exports[`sanitizes empty em blocks to prevent malformed strike-through syntax 1`] = `"~~beforeafter~~"`;
 
-exports[`sanitizes empty em blocks to prevent malformed strong syntax 1`] = `"**before****after**"`;
+exports[`sanitizes empty em blocks to prevent malformed strong syntax 1`] = `"**beforeafter**"`;
 
-exports[`sanitizes empty strike-through blocks to prevent malformed code syntax 1`] = `"\`before\`\`after\`"`;
+exports[`sanitizes empty strike-through blocks to prevent malformed code syntax 1`] = `"\`beforeafter\`"`;
 
-exports[`sanitizes empty strike-through blocks to prevent malformed em syntax 1`] = `"_before__after_"`;
+exports[`sanitizes empty strike-through blocks to prevent malformed em syntax 1`] = `"_beforeafter_"`;
 
 exports[`sanitizes empty strike-through blocks to prevent malformed strike-through syntax 1`] = `"~~beforeafter~~"`;
 
-exports[`sanitizes empty strike-through blocks to prevent malformed strong syntax 1`] = `"**before****after**"`;
+exports[`sanitizes empty strike-through blocks to prevent malformed strong syntax 1`] = `"**beforeafter**"`;
 
-exports[`sanitizes empty strong blocks to prevent malformed code syntax 1`] = `"\`before\`\`after\`"`;
+exports[`sanitizes empty strong blocks to prevent malformed code syntax 1`] = `"\`beforeafter\`"`;
 
-exports[`sanitizes empty strong blocks to prevent malformed em syntax 1`] = `"_before__after_"`;
+exports[`sanitizes empty strong blocks to prevent malformed em syntax 1`] = `"_beforeafter_"`;
 
-exports[`sanitizes empty strong blocks to prevent malformed strike-through syntax 1`] = `"~~before~~~~after~~"`;
+exports[`sanitizes empty strong blocks to prevent malformed strike-through syntax 1`] = `"~~beforeafter~~"`;
 
 exports[`sanitizes empty strong blocks to prevent malformed strong syntax 1`] = `"**beforeafter**"`;
 
-exports[`sanitizes empty underline blocks to prevent malformed code syntax 1`] = `"\`before\`\`after\`"`;
+exports[`sanitizes empty underline blocks to prevent malformed code syntax 1`] = `"\`beforeafter\`"`;
 
-exports[`sanitizes empty underline blocks to prevent malformed em syntax 1`] = `"_before__after_"`;
+exports[`sanitizes empty underline blocks to prevent malformed em syntax 1`] = `"_beforeafter_"`;
 
-exports[`sanitizes empty underline blocks to prevent malformed strike-through syntax 1`] = `"~~before~~~~after~~"`;
+exports[`sanitizes empty underline blocks to prevent malformed strike-through syntax 1`] = `"~~beforeafter~~"`;
 
-exports[`sanitizes empty underline blocks to prevent malformed strong syntax 1`] = `"**before****after**"`;
+exports[`sanitizes empty underline blocks to prevent malformed strong syntax 1`] = `"**beforeafter**"`;

--- a/test/__snapshots__/toMarkdown.test.js.snap
+++ b/test/__snapshots__/toMarkdown.test.js.snap
@@ -339,3 +339,11 @@ Lorem ipsum"
 `;
 
 exports[`061-missing-mark-serializer 1`] = `"A word of _warning;_ Sanity is addictive."`;
+
+exports[`places code symbols appropriately with respect to whitespace 1`] = `"\`   Sanity   \`"`;
+
+exports[`places em symbols appropriately with respect to whitespace 1`] = `"_   Sanity   _"`;
+
+exports[`places strike-through symbols appropriately with respect to whitespace 1`] = `"~~   Sanity   ~~"`;
+
+exports[`places strong symbols appropriately with respect to whitespace 1`] = `"**   Sanity   **"`;

--- a/test/__snapshots__/toMarkdown.test.js.snap
+++ b/test/__snapshots__/toMarkdown.test.js.snap
@@ -342,8 +342,10 @@ exports[`061-missing-mark-serializer 1`] = `"A word of _warning;_ Sanity is addi
 
 exports[`places code symbols appropriately with respect to whitespace 1`] = `"\`   Sanity   \`"`;
 
-exports[`places em symbols appropriately with respect to whitespace 1`] = `"_   Sanity   _"`;
+exports[`places em symbols appropriately with respect to whitespace 1`] = `"_Sanity_"`;
 
-exports[`places strike-through symbols appropriately with respect to whitespace 1`] = `"~~   Sanity   ~~"`;
+exports[`places nested marks appropriately with respect to whitespace 1`] = `"~~before   **_Sanity_**~~   after"`;
 
-exports[`places strong symbols appropriately with respect to whitespace 1`] = `"**   Sanity   **"`;
+exports[`places strike-through symbols appropriately with respect to whitespace 1`] = `"~~Sanity~~"`;
+
+exports[`places strong symbols appropriately with respect to whitespace 1`] = `"**Sanity**"`;

--- a/test/toMarkdown.test.js
+++ b/test/toMarkdown.test.js
@@ -107,3 +107,51 @@ test('places nested marks appropriately with respect to whitespace', () => {
 
   expect(toMarkdown(input, options)).toMatchSnapshot()
 })
+
+function getSplitEmptyMarkInput(mark, emptyMarks) {
+  return [
+    {
+      _type: 'block',
+      children: [
+        {
+          _type: 'span',
+          marks: [mark],
+          text: 'before',
+        },
+        {
+          _type: 'span',
+          marks: emptyMarks,
+          text: '',
+        },
+        {
+          _type: 'span',
+          marks: [mark],
+          text: 'after',
+        },
+      ],
+      markDefs: [],
+    },
+  ]
+}
+
+;['strike-through', 'em', 'strong', 'underline'].forEach((emptyMark) => {
+  ;['strike-through', 'em', 'code', 'strong'].forEach((mark) => {
+    test(`sanitizes empty ${emptyMark} blocks to prevent malformed ${mark} syntax`, () => {
+      expect(toMarkdown(getSplitEmptyMarkInput(mark, [emptyMark]), options)).toMatchSnapshot()
+    })
+  })
+})
+;['strike-through', 'em', 'strong', 'underline'].forEach((mark) => {
+  test(`allows empty code marks between ${mark} marks`, () => {
+    expect(toMarkdown(getSplitEmptyMarkInput(mark, ['code']), options)).toMatchSnapshot()
+  })
+})
+;['strike-through', 'em', 'strong', 'underline'].forEach((emptyMark) => {
+  ;['strike-through', 'em', 'strong', 'underline'].forEach((mark) => {
+    test(`after sanitiziation - allows empty code marks between ${mark} marks`, () => {
+      expect(
+        toMarkdown(getSplitEmptyMarkInput(mark, ['code', emptyMark]), options)
+      ).toMatchSnapshot()
+    })
+  })
+})

--- a/test/toMarkdown.test.js
+++ b/test/toMarkdown.test.js
@@ -15,7 +15,7 @@ test('renders empty block array as empty string', () => {
   expect(toMarkdown([])).toEqual('')
 })
 
-const code = (props) => `\`\`\`${props.node.language}\n${props.node.code}\n\`\`\``
+const code = props => `\`\`\`${props.node.language}\n${props.node.code}\n\`\`\``
 const highlight = ({mark, children}) => {
   const content = Array.isArray(children) ? children.join('') : children
   return `<span style="border: ${mark.thickness}px solid;">${content}</span>`
@@ -23,14 +23,14 @@ const highlight = ({mark, children}) => {
 
 const testsDir = path.dirname(require.resolve('@sanity/block-content-tests'))
 const fixturesDir = path.join(testsDir, 'fixtures')
-const fixtures = fs.readdirSync(fixturesDir).filter((file) => path.extname(file) === '.js')
+const fixtures = fs.readdirSync(fixturesDir).filter(file => path.extname(file) === '.js')
 const options = {
   projectId: '3do82whm',
   dataset: 'production',
-  serializers: {types: {code}, marks: {highlight}},
+  serializers: {types: {code}, marks: {highlight}}
 }
 
-fixtures.forEach((fixture) => {
+fixtures.forEach(fixture => {
   const {input} = require(path.join(fixturesDir, fixture))
   test(fixture.slice(0, -3), () => {
     expect(toMarkdown(input, options)).toMatchSnapshot()
@@ -51,30 +51,30 @@ function getMarkedInput(mark, text = '   Sanity   ') {
         {
           _type: 'span',
           marks: [],
-          text: 'before',
+          text: 'before'
         },
         {
           _type: 'span',
           marks: [mark],
-          text: text,
+          text: text
         },
         {
           _type: 'span',
           marks: [],
-          text: 'after',
-        },
+          text: 'after'
+        }
       ],
-      markDefs: [],
-    },
+      markDefs: []
+    }
   ]
 }
 
-;['strike-through', 'em', 'code', 'strong'].forEach((mark) => {
+;['strike-through', 'em', 'code', 'strong'].forEach(mark => {
   test(`places ${mark} symbols appropriately with respect to whitespace`, () => {
     expect(toMarkdown(getMarkedInput(mark), options)).toMatchSnapshot()
   })
 })
-;['strike-through', 'em', 'strong'].forEach((mark) => {
+;['strike-through', 'em', 'strong'].forEach(mark => {
   it(`does not include ${mark} symbols around empty content`, () => {
     expect(toMarkdown(getMarkedInput(mark, ' '))).toMatchSnapshot()
   })
@@ -88,21 +88,21 @@ test('places nested marks appropriately with respect to whitespace', () => {
         {
           _type: 'span',
           text: '  before',
-          marks: ['strike-through'],
+          marks: ['strike-through']
         },
         {
           _type: 'span',
           marks: ['em', 'strike-through', 'strong'],
 
-          text: '   Sanity   ',
+          text: '   Sanity   '
         },
         {
           _type: 'span',
-          text: 'after  ',
-        },
+          text: 'after  '
+        }
       ],
-      markDefs: [],
-    },
+      markDefs: []
+    }
   ]
 
   expect(toMarkdown(input, options)).toMatchSnapshot()
@@ -116,38 +116,38 @@ function getSplitEmptyMarkInput(mark, emptyMarks) {
         {
           _type: 'span',
           marks: [mark],
-          text: 'before',
+          text: 'before'
         },
         {
           _type: 'span',
           marks: emptyMarks,
-          text: '',
+          text: ''
         },
         {
           _type: 'span',
           marks: [mark],
-          text: 'after',
-        },
+          text: 'after'
+        }
       ],
-      markDefs: [],
-    },
+      markDefs: []
+    }
   ]
 }
 
-;['strike-through', 'em', 'strong', 'underline'].forEach((emptyMark) => {
-  ;['strike-through', 'em', 'code', 'strong'].forEach((mark) => {
+;['strike-through', 'em', 'strong', 'underline'].forEach(emptyMark => {
+  ;['strike-through', 'em', 'code', 'strong'].forEach(mark => {
     test(`sanitizes empty ${emptyMark} blocks to prevent malformed ${mark} syntax`, () => {
       expect(toMarkdown(getSplitEmptyMarkInput(mark, [emptyMark]), options)).toMatchSnapshot()
     })
   })
 })
-;['strike-through', 'em', 'strong', 'underline'].forEach((mark) => {
+;['strike-through', 'em', 'strong', 'underline'].forEach(mark => {
   test(`allows empty code marks between ${mark} marks`, () => {
     expect(toMarkdown(getSplitEmptyMarkInput(mark, ['code']), options)).toMatchSnapshot()
   })
 })
-;['strike-through', 'em', 'strong', 'underline'].forEach((emptyMark) => {
-  ;['strike-through', 'em', 'strong', 'underline'].forEach((mark) => {
+;['strike-through', 'em', 'strong', 'underline'].forEach(emptyMark => {
+  ;['strike-through', 'em', 'strong', 'underline'].forEach(mark => {
     test(`after sanitiziation - allows empty code marks between ${mark} marks`, () => {
       expect(
         toMarkdown(getSplitEmptyMarkInput(mark, ['code', emptyMark]), options)

--- a/test/toMarkdown.test.js
+++ b/test/toMarkdown.test.js
@@ -43,15 +43,25 @@ test('builds images with passed query params', () => {
   expect(result).toContain('5748x3832.jpg?w=320&h=240')
 })
 
-function getMarkedInput(mark) {
+function getMarkedInput(mark, text = '   Sanity   ') {
   return [
     {
       _type: 'block',
       children: [
         {
           _type: 'span',
+          marks: [],
+          text: 'before',
+        },
+        {
+          _type: 'span',
           marks: [mark],
-          text: '   Sanity   ',
+          text: text,
+        },
+        {
+          _type: 'span',
+          marks: [],
+          text: 'after',
         },
       ],
       markDefs: [],
@@ -62,6 +72,11 @@ function getMarkedInput(mark) {
 ;['strike-through', 'em', 'code', 'strong'].forEach((mark) => {
   test(`places ${mark} symbols appropriately with respect to whitespace`, () => {
     expect(toMarkdown(getMarkedInput(mark), options)).toMatchSnapshot()
+  })
+})
+;['strike-through', 'em', 'strong'].forEach((mark) => {
+  it(`does not include ${mark} symbols around empty content`, () => {
+    expect(toMarkdown(getMarkedInput(mark, ' '))).toMatchSnapshot()
   })
 })
 

--- a/test/toMarkdown.test.js
+++ b/test/toMarkdown.test.js
@@ -42,3 +42,25 @@ test('builds images with passed query params', () => {
   const result = toMarkdown(input, {imageOptions: {w: 320, h: 240}})
   expect(result).toContain('5748x3832.jpg?w=320&h=240')
 })
+
+function getMarkedInput(mark) {
+  return [
+    {
+      _type: 'block',
+      children: [
+        {
+          _type: 'span',
+          marks: [mark],
+          text: '   Sanity   ',
+        },
+      ],
+      markDefs: [],
+    },
+  ]
+}
+
+;['strike-through', 'em', 'code', 'strong'].forEach((mark) => {
+  test(`places ${mark} symbols appropriately with respect to whitespace`, () => {
+    expect(toMarkdown(getMarkedInput(mark), options)).toMatchSnapshot()
+  })
+})

--- a/test/toMarkdown.test.js
+++ b/test/toMarkdown.test.js
@@ -15,7 +15,7 @@ test('renders empty block array as empty string', () => {
   expect(toMarkdown([])).toEqual('')
 })
 
-const code = props => `\`\`\`${props.node.language}\n${props.node.code}\n\`\`\``
+const code = (props) => `\`\`\`${props.node.language}\n${props.node.code}\n\`\`\``
 const highlight = ({mark, children}) => {
   const content = Array.isArray(children) ? children.join('') : children
   return `<span style="border: ${mark.thickness}px solid;">${content}</span>`
@@ -23,14 +23,14 @@ const highlight = ({mark, children}) => {
 
 const testsDir = path.dirname(require.resolve('@sanity/block-content-tests'))
 const fixturesDir = path.join(testsDir, 'fixtures')
-const fixtures = fs.readdirSync(fixturesDir).filter(file => path.extname(file) === '.js')
+const fixtures = fs.readdirSync(fixturesDir).filter((file) => path.extname(file) === '.js')
 const options = {
   projectId: '3do82whm',
   dataset: 'production',
-  serializers: {types: {code}, marks: {highlight}}
+  serializers: {types: {code}, marks: {highlight}},
 }
 
-fixtures.forEach(fixture => {
+fixtures.forEach((fixture) => {
   const {input} = require(path.join(fixturesDir, fixture))
   test(fixture.slice(0, -3), () => {
     expect(toMarkdown(input, options)).toMatchSnapshot()
@@ -63,4 +63,32 @@ function getMarkedInput(mark) {
   test(`places ${mark} symbols appropriately with respect to whitespace`, () => {
     expect(toMarkdown(getMarkedInput(mark), options)).toMatchSnapshot()
   })
+})
+
+test('places nested marks appropriately with respect to whitespace', () => {
+  const input = [
+    {
+      _type: 'block',
+      children: [
+        {
+          _type: 'span',
+          text: '  before',
+          marks: ['strike-through'],
+        },
+        {
+          _type: 'span',
+          marks: ['em', 'strike-through', 'strong'],
+
+          text: '   Sanity   ',
+        },
+        {
+          _type: 'span',
+          text: 'after  ',
+        },
+      ],
+      markDefs: [],
+    },
+  ]
+
+  expect(toMarkdown(input, options)).toMatchSnapshot()
 })


### PR DESCRIPTION
:wave:

Hello, we use `block-content-to-markdown` text to convert sanity block text to markdown and we found an issue where spans with emphasis,  strong, or strike-through marks can result in inappropriate markdown when there is leading or trailing whitespace within the span's text.  Markdown requires emphasis, strong, and strike-through marks to contain no leading or trailing whitespace. Code marks are the exemption here as they can contain leading and trailing whitespace. During development of this fix we also realized that the strike-through, emphasis, and strong serializers can result in those marks wrapping empty content, which is also undesirable.

Examples:

Valid:
~~strike-through~~ (`~~strike-through`)
_emphasis_ (`_emphasis_`)
**strong** (`**strong**`)
`code` (`` `code` ``)
.`  code  `. (`` .`  code  `. ``)

Misrendered:
~~ strike-through ~~ (`~~ strike-through ~~`)
_ emphasis _ (`_ emphasis _`)
** strong ** (`** strong **`)

The first commit here includes snapshot tests that highlight the issue by including tests where spans with leading and trailing whitespace result in inappropriate markdown.

The second commit expands `RawMarkSerializer` to allow for a `padWhitespace` argument, that when true will search the `children` (result of `renderChildren(props)`) for the first and last non-whitespace characters and generate substrings based on those indexes so the passed `char` can be placed appropriately.  The appropriate `padWhitespace` value is set when the function is bound for the corresponding marks. `strike-through`, `em` and `strong` bind `padWhitespace` as true, while `code` binds it as false.

The third commit adds handling for the case where a mark has been included around empty content to avoid rendering empty em, strong, or strikethrough content, for example:

~~ (`~~`)
__ (`__`)
** (`**`)
~ ~ (`~ ~`)
_ _ (`_ _`)
** (`* *`)

Lastly, the fourth and fifth commits demonstrate an issue where completely empty spans (text is the empty string) with em, strong, strikethrough or underline marks can also result in undesireable markdown. Because we are now not rendering the marks when the text is all whitespace, if the text of a span is the empty string and it has 1 or more of only those marks , surrounding markdown with marks that should be collapsed are not collapsed. To combat this, we can sanitize the block input and recursively remove any spans where the text is empty and the marks only includes the disallowed empty marks (em, strong, strikethrough, underline). This allows the surrounding spans' marks to be collapsed if appropriate.

The fourth commit adds tests to demonstrate the issues, while the second fixes them by calling `sanitizeEmptyMarkedSpans` on the passed blocks before passing them to `props` in `blocksToNodes`. See the test and snapshots in the 4th commit for examples of undesired markdown and observe those same snapshots in the 5th commit to see the desired result.

 An example of this issue would be:

**strong text****strong text** (`**strong text****strong text**`)

which should be:

**strong textstrong text** (`**strong textstrong text**`)